### PR TITLE
fix: Expose dev server to the local network

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/server_output.log
+++ b/server_output.log
@@ -1,0 +1,9 @@
+
+> vibeshare-code-create@1.0.0 dev
+> vite --host
+
+
+  VITE v5.4.19  ready in 595 ms
+
+  ➜  Local:   http://localhost:3000/
+  ➜  Network: http://192.168.0.2:3000/


### PR DESCRIPTION
The Vite development server was not accessible from other devices on the local network because it was bound to localhost by default.

This change adds the '--host' flag to the 'dev' script in package.json, allowing other devices on the network to access the application during development. This resolves the issue where the app appeared to have an "API call error" on other devices, which was likely due to the inability to connect to the dev server.